### PR TITLE
hard time-limit and parsimony based stopping criteria added

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ larch-usher options:
 - `--quiet` [Default: write intermediate files] Do not write intermediate protobuf file at each iteration.
 - `--input-format` [Default: format inferred by file extension] Specify the format of the input file. Options are: (`dagbin`, `pb`, `dag-pb`, `tree-pb`, `json`, `dag-json`)
 - `--output-format` [Default: format inferred by file extension] Specify the format of the output file. Options are: (`dagbin`, `pb`, `dag-pb`)
+- `-S` Enable smart stopping: larch-usher will terminate when parsimony improvement ceases to occur.
+- `-T` specify a hard time limit after which larch-usher will terminate.
 
 ### dag-util
 
@@ -143,7 +145,7 @@ From the `larch/build/` directory:
 ```
 This executable takes a list of protobuf files and merges the resulting DAGs together into one.
 
-merge options:
+dag-util options:
 - `-i,--input` Filepath to the input Tree/DAG (accepted file formats are: MADAG protobuf, MAT protobuf, JSON, Dagbin).
 - `-o,--output` [Default: does not print output] Filepath to the output Tree/DAG (accepted file formats are: MADAG protobuf, Dagbin).
 - `-r,--MAT-refseq-file` [REQUIRED if input protobufs are MAT protobuf format] Filepath to json reference sequence.

--- a/include/larch/impl/spr/batching_callback_impl.hpp
+++ b/include/larch/impl/spr/batching_callback_impl.hpp
@@ -89,6 +89,8 @@ bool BatchingCallback<CRTP, SampleDAG>::operator()(
             }
 #endif
             applied_moves_count_.fetch_add(1);
+          } else {
+            bucket.pop_back();
           }
 
           return accepted.second;


### PR DESCRIPTION
This branch adds two stopping criteria that can be used in addition to the `-c <iter-count>` option in `larch-usher` executable: 
- `-S` option will exit when there ceases to be a change in optimal parsimony scores between iterations. This option defines the quantity  `current_window_size`, which is the number of iterations since the last parsimony improvement. This quantity is incremented every iteration. It also introduces one  called `previous_window_size`, which is the number of steps between the previous parsimony improvement. When the current window size meets 2*`previous_window_size` without improving parsimony, the program exits. Note that this option will override the `-c` option. 
- `-T <time>` specifies(in minutes) a hard time limit at which to exit. Note that this hard time limit is compared to the running total time at the end of each sample-optimize-merge loop, and so it will not guarantee that the program exits on time, but that it exits as soon as it registers the time limit as having been met. This flag can be used in combination with `-S` and `-c` options.


Also a small bug in the way that batching callbacks treat rejected moves is fixed.
